### PR TITLE
Add ros2_sources to ros2-development role

### DIFF
--- a/roles/ros2-development.json
+++ b/roles/ros2-development.json
@@ -16,5 +16,5 @@
     }
   },
   "chef_type": "role",
-  "run_list": [ "recipe[ros2_windows::ros2]" ]
+  "run_list": [ "recipe[ros2_windows::ros2]", "recipe[ros2_windows::ros2_sources]" ]
 }

--- a/roles/ros2-development.json
+++ b/roles/ros2-development.json
@@ -16,5 +16,8 @@
     }
   },
   "chef_type": "role",
-  "run_list": [ "recipe[ros2_windows::ros2]", "recipe[ros2_windows::ros2_sources]" ]
+  "run_list": [ 
+    "recipe[ros2_windows::ros2]", 
+    "recipe[ros2_windows::ros2_sources]" 
+  ]
 }


### PR DESCRIPTION
It seems like in general we probably want the sources for the dev role?