### PR TITLE
Use chocolatey_package resource and pin cppcheck version.

### DIFF
--- a/cookbooks/ros2_windows/recipes/chocolatey_installs.rb
+++ b/cookbooks/ros2_windows/recipes/chocolatey_installs.rb
@@ -1,5 +1,9 @@
-execute 'cppcheck' do
-  command 'choco install -y git cmake curl vcredist2013 vcredist140 patch cppcheck'
+%w[git cmake curl vcredist2013 vcredist140 patch].each do |pkg|
+  chocolatey_package pkg
+end
+
+chocolatey_package 'cppcheck' do
+  version '1.90'
 end
 
 windows_env 'PATH' do


### PR DESCRIPTION
The latest round of testing has issues with cppcheck 2.0 which are still being worked on. We need to propagate the pin but I also saw and forgot why this was being done with an execute resource rather than a chocolatey_package resource.

So this PR includes two changes.

* Use chocolatey_package resource to install chocolatey packages.
* Install cppcheck at version 1.90.