### PR TITLE
Correct installer location and opencv path

### DIFF
--- a/cookbooks/ros2_windows/recipes/opencv.rb
+++ b/cookbooks/ros2_windows/recipes/opencv.rb
@@ -1,5 +1,5 @@
 seven_zip_archive 'open_cv_zip' do
-  path 'C:\\opencv'
+  path 'C:\\'
   source 'https://github.com/ros2/ros2/releases/download/opencv-archives/opencv-3.4.6-vc16.VS2019.zip'
   overwrite true
 end
@@ -12,7 +12,7 @@ end
 
 windows_env 'PATH' do
   key_name 'PATH'
-  value 'C:\\opencv'
+  value 'C:\\opencv\\x64\\vc16\\bin'
   delim ';'
   action :modify
 end


### PR DESCRIPTION
The image_tools tests were failing due to a class_loader + opencv thing, which I traced back to these environment variables.

Example failure:
Rolling [![Build Status](https://ci.ros2.org/buildStatus/icon?job=test_ci_windows&build=190)](https://ci.ros2.org/job/test_ci_windows/190/)
Rolling Debug [![Build Status](https://ci.ros2.org/buildStatus/icon?job=test_ci_windows&build=191)](https://ci.ros2.org/job/test_ci_windows/191/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>