### PR TITLE
Suppress chef logging of license files.

### DIFF
--- a/cookbooks/ros2_windows/recipes/qt5.rb
+++ b/cookbooks/ros2_windows/recipes/qt5.rb
@@ -10,6 +10,9 @@ cookbook_file 'qtaccount.ini' do
 
   # If the deploying user did not add this file to `files` continue anyway.
   ignore_failure true
+
+  # Suppress diff output so we can use this in public builds.
+  sensitive true
 end
 
 cookbook_file 'qt-installer.qs' do


### PR DESCRIPTION
Although we've been storing this file in private it's been visible in some build logs via the chef logging which shows diffs when placing files.

This flag will suppress the diff during logs.