### PR TITLE
Pin PyQt5 to 5.15.0

### DIFF
--- a/cookbooks/ros2_windows/recipes/pip_installs.rb
+++ b/cookbooks/ros2_windows/recipes/pip_installs.rb
@@ -1,6 +1,6 @@
 required_pip_packages = %w[
   pydot
-  PyQt5
+  PyQt5==5.15.0
   vcstool
   colcon-common-extensions
   catkin_pkg


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Since last week, the Windows nightly CI jobs have been failing on-and-off.  Some examples:

* https://ci.ros2.org/view/nightly/job/nightly_win_extra_rmw_rel/890/
* https://ci.ros2.org/view/nightly/job/nightly_win_rel/1695/
* https://ci.ros2.org/view/nightly/job/nightly_win_xfail/168/

When they fail, it is always the same way:

```
E   ImportError: Could not find Qt binding (looked for: 'pyqt', 'pyside'):
E     ImportError for 'pyqt': No module named 'PyQt5.QtCore'
```

(this is always in the `rqt_py_common`, `rqt_dotgraph`, and `python_qt_binding` packages).  The odd thing about it is that on *some* nights, they succeed.  Unfortunately, I haven't yet gotten to the root cause of why this is happening.

The difference from when they consistently succeeded to when they sometimes fail is that PyQt5 seems to have been upgraded from 5.15.0 to 5.15.1.  So, this is a temporary PR to pin us to PyQt5 5.15.0.  I've run a bunch of test CI jobs, replicating the parameters of nightly jobs, but using this branch.  You can see the results here:

* https://ci.ros2.org/job/ci_windows/12261
* https://ci.ros2.org/job/ci_windows/12262
* https://ci.ros2.org/job/ci_windows/12263

To get the nightlies passing, I suggest we merge this PR (and one that I'll open against https://github.com/ros2/ci to update the submodule), and then spend some time later on figuring out why this is really failing.