### PR TITLE
Revert "Pin PyQt5 to 5.15.0 (#13)"

### DIFF
--- a/cookbooks/ros2_windows/recipes/pip_installs.rb
+++ b/cookbooks/ros2_windows/recipes/pip_installs.rb
@@ -1,6 +1,6 @@
 required_pip_packages = %w[
   pydot
-  PyQt5==5.15.0
+  PyQt5
   vcstool
   colcon-common-extensions
   catkin_pkg


### PR DESCRIPTION
This reverts commit 4ea16252b647994236d23e830e12d61bd8103f03.

We pinned PyQt to 5.15.0 in #13 .  Once we figure out why PyQt 5.15.1 sometimes causes issues with `rqt_pycommon`, `rqt_dotgraph`, and `python_qt_binding`, we can unpin it.  We'll also need to change the submodule in https://github.com/ros2/ci .