### PR TITLE
Update openssl for foxy/rolling to 1.1.1h

### DIFF
--- a/cookbooks/ros2_windows/recipes/openssl.rb
+++ b/cookbooks/ros2_windows/recipes/openssl.rb
@@ -1,8 +1,8 @@
 openssl_versions = {
   "dashing" => "1_0_2u",
   "eloquent" => "1_0_2u",
-  "foxy" => "1_1_1g",
-  "rolling" => "1_1_1g",
+  "foxy" => "1_1_1h",
+  "rolling" => "1_1_1h",
 }.freeze
 
 openssl_version = openssl_versions[node["ros2_windows"]["ros_distro"]]


### PR DESCRIPTION
Openssl 1.1.1g is no longer available for windows from the download link. This updates the version to 1.1.1h.

Windows Build
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12355)](https://ci.ros2.org/job/ci_windows/12355/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>