### PR TITLE
Use Python 3.9.0 for Rolling.

### DIFF
--- a/cookbooks/ros2_windows/recipes/python.rb
+++ b/cookbooks/ros2_windows/recipes/python.rb
@@ -2,7 +2,7 @@ python_versions = {
   "dashing" => "3.7.6",
   "eloquent" => "3.7.6",
   "foxy" => "3.8.3",
-  "rolling" => "3.8.3",
+  "rolling" => "3.9.0",
 }.freeze
 
 python_version = python_versions[node["ros2_windows"]["ros_distro"]]


### PR DESCRIPTION
Initial draft now that 3.9.0 is available and may help addressing issues like https://github.com/ros2/ci/issues/511