### PR TITLE
Unpin cppcheck 1.90.

### DIFF
--- a/cookbooks/ros2_windows/recipes/chocolatey_installs.rb
+++ b/cookbooks/ros2_windows/recipes/chocolatey_installs.rb
@@ -1,9 +1,5 @@
-%w[git cmake curl vcredist2013 vcredist140 patch winflexbison3].each do |pkg|
+%w[git cmake cppcheck curl vcredist2013 vcredist140 patch winflexbison3].each do |pkg|
   chocolatey_package pkg
-end
-
-chocolatey_package 'cppcheck' do
-  version '1.90'
 end
 
 windows_env 'PATH' do


### PR DESCRIPTION
This will install the latest version of cppcheck available from
chocolatey.

Replaces ros2/ci#480's direct revert.