### PR TITLE
Handle 5 character versions like 5.12.10.

### DIFF
--- a/cookbooks/ros2_windows/templates/qt-installer.qs.erb
+++ b/cookbooks/ros2_windows/templates/qt-installer.qs.erb
@@ -122,10 +122,13 @@ var GetDirectoryFromVersion = function GetDirectoryFromVersion(version) {
   // are the major version
   var versionString = String(version);
   var length = version.length;
-  if (length < 3 || length > 4) {
-    throw new Error('Assertion failed: (version.length < 3 || version.length > 4)');
+  if (length == 5) {
+    return versionString[0] + '.' + versionString.slice(1, 2) + '.' + versionString.slice(3, 4);
+  } else if (length >= 3 && length <= 4) {
+    return versionString[0] + '.' + versionString.slice(1, length - 1) + '.' + versionString[length - 1];
+  } else {
+    throw new Error('Unable to build directory from version `' + version + '`.');
   }
-  return versionString[0] + '.' + versionString.slice(1, length - 1) + '.' + versionString[length - 1];
 };
 
 

--- a/cookbooks/ros2_windows/templates/qt-maintenance.qs.erb
+++ b/cookbooks/ros2_windows/templates/qt-maintenance.qs.erb
@@ -129,10 +129,13 @@ var GetDirectoryFromVersion = function GetDirectoryFromVersion(version) {
   // are the major version
   var versionString = String(version);
   var length = version.length;
-  if (length < 3 || length > 4) {
-    throw new Error('Assertion failed: (version.length < 3 || version.length > 4)');
+  if (length == 5) {
+    return versionString[0] + '.' + versionString.slice(1, 2) + '.' + versionString.slice(3, 4);
+  } else if (length >= 3 && length <= 4) {
+    return versionString[0] + '.' + versionString.slice(1, length - 1) + '.' + versionString[length - 1];
+  } else {
+    throw new Error('Unable to build directory from version `' + version + '`.');
   }
-  return versionString[0] + '.' + versionString.slice(1, length - 1) + '.' + versionString[length - 1];
 };
 
 


### PR DESCRIPTION
I caught this while trying to test another issue.

Since these files are templated now at some point it may make sense to move shared code to a shared template but that's a conversation for later.