### PR TITLE
Use 5.12.10 offline installer and skip running of maintenance app

### DIFF
--- a/cookbooks/ros2_windows/recipes/qt5.rb
+++ b/cookbooks/ros2_windows/recipes/qt5.rb
@@ -18,42 +18,42 @@ template  'qt-installer.qs' do
   sensitive true
 end
 
-template  'qt-maintenance.qs' do
-  source 'qt-maintenance.qs.erb'
-  variables Hash[
-    qt_account_email: node['ros2']['qt_account_email'],
-    qt_account_password: node['ros2']['qt_account_password'],
-  ]
-  sensitive true
-end
+#template  'qt-maintenance.qs' do
+#  source 'qt-maintenance.qs.erb'
+#  variables Hash[
+#    qt_account_email: node['ros2']['qt_account_email'],
+#    qt_account_password: node['ros2']['qt_account_password'],
+#  ]
+#  sensitive true
+#end
 
 # Install Qt5 with automated install script, no msvc2019 version exists but 2017 is compatible
 # Updater/silentUpdate options did not work for me.
 # Install scripts finds and installs the most recent LTS version
 error_filename = File.join(Dir.home(), "qt_install.err")
 
-# Update maintenance tool first, if necessary
-windows_package 'Qt Maintenance Update' do
-  source 'c:\\Qt\\MaintenanceTool.exe'
-  installer_type :custom
-  # I couldn't find documentation, but return codes don't seem to correspond with an actual failure.
-  # Instead error information is written to the ErrorLogname below
-  returns [0]
-  options 'up qt.tools.maintenance'
-  timeout 600
-  only_if {::File.exist?('c:\\Qt\\MaintenanceTool.exe')}
-end
-
-windows_package 'Qt Maintenance' do
-  source 'c:\\Qt\\MaintenanceTool.exe'
-  installer_type :custom
-  # I couldn't find documentation, but return codes don't seem to correspond with an actual failure.
-  # Instead error information is written to the ErrorLogname below
-  returns [0, 1, 3]
-  options '--script qt-maintenance.qs MsvcVersion=2019 ErrorLogname="' + error_filename + '"'
-  timeout 2000
-  only_if {::File.exist?('c:\\Qt\\MaintenanceTool.exe')}
-end
+## Update maintenance tool first, if necessary
+#windows_package 'Qt Maintenance Update' do
+#  source 'c:\\Qt\\MaintenanceTool.exe'
+#  installer_type :custom
+#  # I couldn't find documentation, but return codes don't seem to correspond with an actual failure.
+#  # Instead error information is written to the ErrorLogname below
+#  returns [0]
+#  options 'up qt.tools.maintenance'
+#  timeout 600
+#  only_if {::File.exist?('c:\\Qt\\MaintenanceTool.exe')}
+#end
+#
+#windows_package 'Qt Maintenance' do
+#  source 'c:\\Qt\\MaintenanceTool.exe'
+#  installer_type :custom
+#  # I couldn't find documentation, but return codes don't seem to correspond with an actual failure.
+#  # Instead error information is written to the ErrorLogname below
+#  returns [0, 1, 3]
+#  options '--script qt-maintenance.qs MsvcVersion=2019 ErrorLogname="' + error_filename + '"'
+#  timeout 2000
+#  only_if {::File.exist?('c:\\Qt\\MaintenanceTool.exe')}
+#end
 
 windows_package 'Qt Install' do
   source 'http://download.qt.io/official_releases/online_installers/qt-unified-windows-x86-online.exe'

--- a/cookbooks/ros2_windows/recipes/qt5.rb
+++ b/cookbooks/ros2_windows/recipes/qt5.rb
@@ -62,7 +62,7 @@ windows_package 'Qt Install' do
   # I couldn't find documentation, but return codes don't seem to correspond with an actual failure.
   # Instead error information is written to the ErrorLogname below
   returns [0, 1, 3]
-  options %{--st "#{qt_mirror_url}" --script qt-installer.qs MsvcVersion=2019 ErrorLogname="#{error_filename}"}
+  options %{--st "#{qt_mirror_url}" --script qt-installer.qs --verbose MsvcVersion=2019 ErrorLogname="#{error_filename}"}
   timeout 2000
   not_if {::File.exist?('c:\\Qt\\MaintenanceTool.exe')}
 end

--- a/cookbooks/ros2_windows/recipes/qt5.rb
+++ b/cookbooks/ros2_windows/recipes/qt5.rb
@@ -57,7 +57,7 @@ error_filename = File.join(Dir.home(), "qt_install.err")
 
 qt_mirror_url = 'http://qt.mirror.constant.com'
 windows_package 'Qt Install' do
-  source "#{qt_mirror_url}/official_releases/online_installers/qt-unified-windows-x86-online.exe"
+  source "#{qt_mirror_url}/official_releases/qt/5.12/5.12.10/qt-opensource-windows-x86-5.12.10.exe"
   installer_type :custom
   # I couldn't find documentation, but return codes don't seem to correspond with an actual failure.
   # Instead error information is written to the ErrorLogname below

--- a/cookbooks/ros2_windows/recipes/qt5.rb
+++ b/cookbooks/ros2_windows/recipes/qt5.rb
@@ -58,6 +58,7 @@ error_filename = File.join(Dir.home(), "qt_install.err")
 qt_mirror_url = 'http://qt.mirror.constant.com'
 windows_package 'Qt Install' do
   source "#{qt_mirror_url}/official_releases/qt/5.12/5.12.10/qt-opensource-windows-x86-5.12.10.exe"
+  checksum "e315ec89000ae08d51c248f251ce670036b565e1d3a07df50e32557b8fd8246e"
   installer_type :custom
   # I couldn't find documentation, but return codes don't seem to correspond with an actual failure.
   # Instead error information is written to the ErrorLogname below

--- a/cookbooks/ros2_windows/recipes/qt5.rb
+++ b/cookbooks/ros2_windows/recipes/qt5.rb
@@ -55,7 +55,7 @@ error_filename = File.join(Dir.home(), "qt_install.err")
 #  only_if {::File.exist?('c:\\Qt\\MaintenanceTool.exe')}
 #end
 
-qt_mirror_url = 'http://mirrors.ocf.berkeley.edu/qt'
+qt_mirror_url = 'http://qt.mirror.constant.com'
 windows_package 'Qt Install' do
   source "#{qt_mirror_url}/official_releases/online_installers/qt-unified-windows-x86-online.exe"
   installer_type :custom

--- a/cookbooks/ros2_windows/recipes/qt5.rb
+++ b/cookbooks/ros2_windows/recipes/qt5.rb
@@ -55,13 +55,14 @@ error_filename = File.join(Dir.home(), "qt_install.err")
 #  only_if {::File.exist?('c:\\Qt\\MaintenanceTool.exe')}
 #end
 
+qt_mirror_url = 'http://mirrors.ocf.berkeley.edu/qt'
 windows_package 'Qt Install' do
-  source 'http://download.qt.io/official_releases/online_installers/qt-unified-windows-x86-online.exe'
+  source "#{qt_mirror_url}/official_releases/online_installers/qt-unified-windows-x86-online.exe"
   installer_type :custom
   # I couldn't find documentation, but return codes don't seem to correspond with an actual failure.
   # Instead error information is written to the ErrorLogname below
   returns [0, 1, 3]
-  options '--script qt-installer.qs MsvcVersion=2019 ErrorLogname="' + error_filename + '"'
+  options %{--st "#{qt_mirror_url}" --script qt-installer.qs MsvcVersion=2019 ErrorLogname="#{error_filename}"}
   timeout 2000
   not_if {::File.exist?('c:\\Qt\\MaintenanceTool.exe')}
 end

--- a/cookbooks/ros2_windows/recipes/qt5.rb
+++ b/cookbooks/ros2_windows/recipes/qt5.rb
@@ -65,7 +65,7 @@ windows_package 'Qt Install' do
   returns [0, 1, 3]
   options %{--st "#{qt_mirror_url}" --script qt-installer.qs --verbose MsvcVersion=2019 ErrorLogname="#{error_filename}"}
   timeout 2000
-  not_if {::File.exist?('c:\\Qt\\MaintenanceTool.exe')}
+  not_if {::File.exist?('c:\\Qt\\Qt5.12.10\\MaintenanceTool.exe')}
 end
 
 ruby_block 'error_exist?' do


### PR DESCRIPTION
download.qt.io has been offline for 24 hours and counting impacting both the maintenance tool and online installer.

Initially this PR tried using a mirror with the online installer but it still fails attempting to fetch metadata from download.qt.io.

As a last resort this PR is now pinning the last open source binary offline installer for 5.12.10.