### PR TITLE
Fix Visual Studio installation.

### DIFF
--- a/cookbooks/ros2_windows/recipes/visual_studio.rb
+++ b/cookbooks/ros2_windows/recipes/visual_studio.rb
@@ -13,7 +13,9 @@ packages_to_install =  %w[
   Microsoft.VisualStudio.Component.VC.CoreBuildTools
   Microsoft.VisualStudio.Component.VC.CoreIde
   Microsoft.VisualStudio.Component.VC.Redist.14.Latest
+  Microsoft.VisualStudio.Component.VC.Tools.x86.x64
   Microsoft.VisualStudio.Component.Windows10SDK
+  Microsoft.VisualStudio.Component.Windows10SDK.19041
   Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core
   Microsoft.VisualStudio.Workload.MSBuildTools
   Microsoft.VisualStudio.Workload.VCTools

--- a/cookbooks/ros2_windows/recipes/visual_studio.rb
+++ b/cookbooks/ros2_windows/recipes/visual_studio.rb
@@ -14,7 +14,7 @@ if node['ros2_windows']['vs_version'] != 'buildtools' then
 end
 
 package_arguments = packages_to_install.map{ |pkg| '--add ' + pkg}.join(' ')
-base_options = '--quiet --wait --norestart --includeRecommended '
+base_options = '--quiet --wait --norestart '
 
 installer_options = base_options + package_arguments
 

--- a/cookbooks/ros2_windows/recipes/visual_studio.rb
+++ b/cookbooks/ros2_windows/recipes/visual_studio.rb
@@ -3,10 +3,20 @@
 
 # If BuildTools is not already installed, install it
 packages_to_install =  %w[
-  Microsoft.Net.Component.4.8.SDK
-  Microsoft.VisualStudio.Workload.VCTools
   Microsoft.Component.MSBuild
+  Microsoft.Net.Component.4.6.1.TargetingPack
+  Microsoft.Net.Component.4.8.SDK
+  Microsoft.VisualStudio.Component.CoreBuildTools
+  Microsoft.VisualStudio.Component.Roslyn.Compiler
+  Microsoft.VisualStudio.Component.TextTemplating
   Microsoft.VisualStudio.Component.VC.CLI.Support
+  Microsoft.VisualStudio.Component.VC.CoreBuildTools
+  Microsoft.VisualStudio.Component.VC.CoreIde
+  Microsoft.VisualStudio.Component.VC.Redist.14.Latest
+  Microsoft.VisualStudio.Component.Windows10SDK
+  Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core
+  Microsoft.VisualStudio.Workload.MSBuildTools
+  Microsoft.VisualStudio.Workload.VCTools
 ]
 
 if node['ros2_windows']['vs_version'] != 'buildtools' then


### PR DESCRIPTION
The `--includeRecommended` parameter was seemingly removed with no clear replacement. After a few rounds of whack-a-mole I think I've settled on an explicit package list which installs the needed components.