### PR TITLE
Update to openssl1_1_1k after j version was removed - fix 404 errors 

### DIFF
--- a/cookbooks/ros2_windows/recipes/openssl.rb
+++ b/cookbooks/ros2_windows/recipes/openssl.rb
@@ -1,8 +1,8 @@
 openssl_versions = {
   "dashing" => "1_0_2u",
   "eloquent" => "1_0_2u",
-  "foxy" => "1_1_1j",
-  "rolling" => "1_1_1j",
+  "foxy" => "1_1_1k",
+  "rolling" => "1_1_1k",
 }.freeze
 
 openssl_version = openssl_versions[node["ros2_windows"]["ros_distro"]]


### PR DESCRIPTION
See for example https://ci.ros2.org/job/ci_windows/14186/console - Windows CI is now failing because https://slproweb.com/download/Win64OpenSSL-1_1_1j.exe was removed from the download server - that's a 404 now. The new version https://slproweb.com/download/Win64OpenSSL-1_1_1k.exe is a valid link. I hope the builds all work!