### PR TITLE
Pin cookbook dependency versions in metadata.

### DIFF
--- a/cookbooks/ros2_windows/metadata.rb
+++ b/cookbooks/ros2_windows/metadata.rb
@@ -18,6 +18,6 @@ chef_version '>= 12.1' if respond_to?(:chef_version)
 # a Supermarket.
 #
 # source_url 'https://github.com/osrf/chef-osrf'
-depends 'chocolatey'
-depends 'seven_zip'
-depends 'windows'
+depends 'chocolatey', '3.0.0'
+depends 'seven_zip', '3.2.0'
+depends 'windows', '7.0.2'


### PR DESCRIPTION
Motivated immediately by seven_zip 4.0 dropping support for Chef 15.

We're using Chef/Cinc 15 on Windows until some underlying issues can be resolved. One of our cookbook dependencies has had a major version bump which drops Chef 15 support.

I pinned all dependent cookbooks because we really don't want infrastructure churn and there's minimal reason to update cookbooks if we aren't experiencing bugs.

Still to investigate is why a "lockfile" which pins the transitive set of dependencies is not committed in this repository. It could either have been intentional to track update drift like leaving the dependencies unpinned in metadata.rb or it could have just been the result of the fact that we don't develop on Windows and so do not run the utility locally to generate and commit a lockfile.