### PR TITLE
Drop Windows cookbook.

### DIFF
--- a/cookbooks/ros2_windows/metadata.rb
+++ b/cookbooks/ros2_windows/metadata.rb
@@ -20,4 +20,3 @@ chef_version '>= 12.1' if respond_to?(:chef_version)
 # source_url 'https://github.com/osrf/chef-osrf'
 depends 'chocolatey', '3.0.0'
 depends 'seven_zip', '3.2.0'
-depends 'windows', '7.0.2'


### PR DESCRIPTION
The Windows cookbook is listed as deprecated and as far as I can tell
the Windows-specific resources we're using are included in Chef as of at
least Chef 14.

This is a "remove it and see what breaks" patch.