### PR TITLE
Use download.ros.org for hosting OpenSSL installer

### DIFF
--- a/cookbooks/ros2_windows/recipes/openssl.rb
+++ b/cookbooks/ros2_windows/recipes/openssl.rb
@@ -21,7 +21,7 @@ openssl_conf_dir = if openssl_version == "1_0_2u"
 
 
 windows_package 'openssl' do
-  source "https://slproweb.com/download/Win64OpenSSL-#{openssl_version}.exe"
+  source "https://ftp.osuosl.org/pub/ros/download.ros.org/downloads/openssl/Win64OpenSSL-#{openssl_version}.exe"
   options '/VERYSILENT'
 end
 


### PR DESCRIPTION
We don't have a verified copy of the 1.0.2u binary yet, but we do have the 1.1.1k binary live. This will unblock builds for Foxy and newer.