### PR TITLE
Pin mypy to version used in Ubuntu 20.04.

### DIFF
--- a/cookbooks/ros2_windows/recipes/pip_installs.rb
+++ b/cookbooks/ros2_windows/recipes/pip_installs.rb
@@ -30,7 +30,7 @@ development_pip_packages = %w[
   flake8-docstrings
   flake8-import-order
   flake8-quotes
-  mypy
+  mypy==0.761
   pep8
   pydocstyle
 ]


### PR DESCRIPTION
All current distributions are pinning mypy to the version used by Ubuntu Focal due to recent changes in the latest mypy releases. See https://github.com/ros2/ci/pull/581 for details.