### PR TITLE
Update version of openssl 1.1.1.

### DIFF
--- a/cookbooks/ros2_windows/recipes/openssl.rb
+++ b/cookbooks/ros2_windows/recipes/openssl.rb
@@ -1,9 +1,9 @@
 openssl_versions = {
   "dashing" => "1_0_2u",
   "eloquent" => "1_0_2u",
-  "foxy" => "1_1_1k",
-  "galactic" => "1_1_1k",
-  "rolling" => "1_1_1k",
+  "foxy" => "1_1_1L",
+  "galactic" => "1_1_1L",
+  "rolling" => "1_1_1L",
 }.freeze
 
 openssl_version = openssl_versions[node["ros2_windows"]["ros_distro"]]


### PR DESCRIPTION
1.1.1k -> 1.1.1L

This binary has also been mirrored on download.ros.org.