### PR TITLE
Update xmllint download url.

### DIFF
--- a/cookbooks/ros2_windows/attributes/xmllint.rb
+++ b/cookbooks/ros2_windows/attributes/xmllint.rb
@@ -1,0 +1,1 @@
+default['ros2_windows']['xmllint']['xmllint_download_url'] = 'https://www.zlatkovic.com/pub/libxml/64bit/'

--- a/cookbooks/ros2_windows/attributes/xmllint.rb
+++ b/cookbooks/ros2_windows/attributes/xmllint.rb
@@ -1,1 +1,1 @@
-default['ros2_windows']['xmllint']['xmllint_download_url'] = 'https://www.zlatkovic.com/pub/libxml/64bit/'
+default['ros2_windows']['xmllint']['xmllint_download_url'] = 'https://ftp.osuosl.org/pub/ros/download.ros.org/downloads/libxml/'

--- a/cookbooks/ros2_windows/attributes/xmllint.rb
+++ b/cookbooks/ros2_windows/attributes/xmllint.rb
@@ -1,1 +1,1 @@
-default['ros2_windows']['xmllint']['xmllint_download_url'] = 'https://ftp.osuosl.org/pub/ros/download.ros.org/downloads/libxml/'
+default['ros2_windows']['xmllint']['xmllint_download_url'] = 'https://www.zlatkovic.com/pub/libxml/64bit/'

--- a/cookbooks/ros2_windows/recipes/xmllint.rb
+++ b/cookbooks/ros2_windows/recipes/xmllint.rb
@@ -1,19 +1,19 @@
 xmllint_url = node['ros2_windows']['xmllint']['xmllint_download_url']
 seven_zip_archive 'libxml2' do
   path 'C:\\xmllint'
-  source xmllint_url + 'libxml2-2.9.3-win32-x86_64.7z'
+  source xmllint_url + '/libxml2-2.9.3-win32-x86_64.7z'
   overwrite true
 end
 
 seven_zip_archive 'zlib' do
   path 'C:\\xmllint'
-  source xmllint_url + 'zlib-1.2.8-win32-x86_64.7z'
+  source xmllint_url + '/zlib-1.2.8-win32-x86_64.7z'
   overwrite true
 end
 
 seven_zip_archive 'iconv' do
   path 'C:\\xmllint'
-  source xmllint_url + 'iconv-1.14-win32-x86_64.7z'
+  source xmllint_url + '/iconv-1.14-win32-x86_64.7z'
   overwrite true
 end
 

--- a/cookbooks/ros2_windows/recipes/xmllint.rb
+++ b/cookbooks/ros2_windows/recipes/xmllint.rb
@@ -1,18 +1,19 @@
+xmllint_url = node['ros2_windows']['xmllint']['xmllint_download_url']
 seven_zip_archive 'libxml2' do
   path 'C:\\xmllint'
-  source 'https://www.zlatkovic.com/pub/libxml/64bit/libxml2-2.9.3-win32-x86_64.7z'
+  source xmllint_url + 'libxml2-2.9.3-win32-x86_64.7z'
   overwrite true
 end
 
 seven_zip_archive 'zlib' do
   path 'C:\\xmllint'
-  source 'https://www.zlatkovic.com/pub/libxml/64bit/zlib-1.2.8-win32-x86_64.7z'
+  source xmllint_url + 'zlib-1.2.8-win32-x86_64.7z'
   overwrite true
 end
 
 seven_zip_archive 'iconv' do
   path 'C:\\xmllint'
-  source 'https://www.zlatkovic.com/pub/libxml/64bit/iconv-1.14-win32-x86_64.7z'
+  source xmllint_url + 'iconv-1.14-win32-x86_64.7z'
   overwrite true
 end
 


### PR DESCRIPTION
There are two commits here, one which refactors the downloads to use a single url path set via chef attribute and a second to change that attribute to point to the ROS download server (via OSUOSL FTP endpoint for proper https support) in order to work around outdated root CA info in the chef version used in these builds. Updating Chef is another more complete solution which will take time. This is meant to get us running in the meantime.