### PR TITLE
Use chef-workstation package to bootstrap cookbook dependencies.

### DIFF
--- a/cookbooks/ros2_windows/README.md
+++ b/cookbooks/ros2_windows/README.md
@@ -21,7 +21,7 @@ In powershell, install Cinc's chef distribution:
 In same shell, install chocolatey, git and the chefdk tools (primarily for `berks`).
 ```
 > Set-ExecutionPolicy Bypass -Scope Process -Force;. { iwr -useb https://chocolatey.org/install.ps1 } | iex
-> choco install -y git chefdk
+> choco install -y git chef-workstation
 > restart-computer
 ```
 


### PR DESCRIPTION
The chefdk package has been removed but chef-workstation is the successor project containing the same tools.

This change was made in our CI with [`367d755` (#597)](https://github.com/ros2/ci/pull/597/commits/367d755e8b070b5623a5ed34173ba77035cb7e3f)