### PR TITLE
Set CONNEXTDDS_DIR environment variable.

### DIFF
--- a/cookbooks/ros2_windows/recipes/rti_connext.rb
+++ b/cookbooks/ros2_windows/recipes/rti_connext.rb
@@ -76,8 +76,9 @@ target_installer_filename = "rti_connext_dds-#{connext_params['version']}-#{conn
 target_installer_path = File.join(connext_params['installer_dir'],
                                   target_installer_filename)
 
-rtipkginstall_bat = File.join(ENV['ProgramFiles'],
-                              "rti_connext_dds-#{connext_params['version']}",
+connextdds_dir = File.join(ENV['ProgramFiles'], "rti_connext_dds-#{connest_params['version']}")
+
+rtipkginstall_bat = File.join(connextdds_dir,
                               'bin',
                               'rtipkginstall.bat')
 

--- a/cookbooks/ros2_windows/recipes/rti_connext.rb
+++ b/cookbooks/ros2_windows/recipes/rti_connext.rb
@@ -76,7 +76,7 @@ target_installer_filename = "rti_connext_dds-#{connext_params['version']}-#{conn
 target_installer_path = File.join(connext_params['installer_dir'],
                                   target_installer_filename)
 
-connextdds_dir = File.join(ENV['ProgramFiles'], "rti_connext_dds-#{connest_params['version']}")
+connextdds_dir = File.join(ENV['ProgramFiles'], "rti_connext_dds-#{connext_params['version']}")
 
 rtipkginstall_bat = File.join(connextdds_dir,
                               'bin',
@@ -146,6 +146,12 @@ end
 
 execute 'rtipkginstall_rti_security_plugins_target' do
   command "\"#{rtipkginstall_bat}\" #{security_plugins_target_path}"
+end
+
+windows_env 'CONNEXTDDS_DIR' do
+  key_name 'CONNEXTDDS_DIR'
+  value connextdds_dir
+  action :create
 end
 
 windows_env 'RTI_OPENSSL_BIN' do


### PR DESCRIPTION
This environment variable is used by rti_connext_dds_cmake_module to find a local Connext DDS installation.