### PR TITLE
Retry chocolatey installations with debug information.

### DIFF
--- a/cookbooks/ros2_windows/recipes/chocolatey_installs.rb
+++ b/cookbooks/ros2_windows/recipes/chocolatey_installs.rb
@@ -2,7 +2,7 @@
   chocolatey_package pkg do
     options "--debug"
     list_options "--debug"
-    retries 10
+    retries 20
     retry_delay 10
   end
 end

--- a/cookbooks/ros2_windows/recipes/chocolatey_installs.rb
+++ b/cookbooks/ros2_windows/recipes/chocolatey_installs.rb
@@ -1,5 +1,10 @@
 %w[git cmake curl vcredist2013 vcredist140 patch winflexbison3].each do |pkg|
-  chocolatey_package pkg
+  chocolatey_package pkg do
+    options "--debug"
+    list_options "--debug"
+    retries 10
+    retry_delay 10
+  end
 end
 
 chocolatey_package 'cppcheck' do


### PR DESCRIPTION
Chocolatey installation has become profoundly unreliable.
Since a successful build will eventially be cached the aggressive retry values here (possible 100 second delays per package) are of little significance compared to losing a day's worth of builds.

Hopefully the addition of debug information will also help us figure out what is happening when Chocolatey does fail.

```
09:52:55 Recipe: ros2_windows::chocolatey_installs
09:52:55   * chocolatey_package[git] action install (up to date)
09:52:58   * chocolatey_package[cmake] action install
09:53:01     * No candidate version available for cmake
09:53:33     - install version 3.22.2 of package cmake
09:53:33   * chocolatey_package[curl] action install
09:53:36     * No candidate version available for curl
09:53:48     * No candidate version available for curl
09:54:00     * No candidate version available for curl
09:54:18     - install version 7.81.0 of package curl
09:54:18   * chocolatey_package[vcredist2013] action install
09:54:34     - install version 12.0.40660.20180427 of package vcredist2013
09:54:34   * chocolatey_package[vcredist140] action install
09:54:36     * No candidate version available for vcredist140
09:55:10     - install version 14.31.31103 of package vcredist140
09:55:10   * chocolatey_package[patch] action install
09:55:25     - install version 2.5.9 of package patch
09:55:25   * chocolatey_package[winflexbison3] action install
09:55:35     - install version 2.5.24.20210105 of package winflexbison3
09:55:35   * chocolatey_package[cppcheck] action install
09:55:47     - install version 1.90 of package cppcheck
```