### PR TITLE
Update bullet chocolatey package to 3.17

### DIFF
--- a/cookbooks/ros2_windows/recipes/chocolatey_installs.rb
+++ b/cookbooks/ros2_windows/recipes/chocolatey_installs.rb
@@ -20,7 +20,7 @@ end
 
 custom_chocolatey_packages = {
   'asio' => 'asio.1.12.1',
-  'bullet' => 'bullet.2.89.0',
+  'bullet' => 'bullet.3.17',
   'cunit' => 'cunit.2.1.3',
   'eigen' => 'eigen.3.3.4',
   'log4cxx' => 'log4cxx.0.10.0',
@@ -30,7 +30,7 @@ custom_chocolatey_packages = {
 
 custom_chocolatey_packages.each do |name, pkg|
   remote_file "#{pkg}.nupkg" do
-    source "https://github.com/ros2/choco-packages/releases/download/2020-02-24/#{pkg}.nupkg"
+    source "https://github.com/ros2/choco-packages/releases/download/2022-03-15/#{pkg}.nupkg"
   end
 
   chocolatey_package 'custom_packages' do


### PR DESCRIPTION
https://github.com/ros2/choco-packages/pull/18
https://github.com/ros2/choco-packages/releases/tag/2022-03-15

This makes Windows CI use the updated bullet package.

Signed-off-by: Shane Loretz <sloretz@openrobotics.org>