### PR TITLE
Pin setuptools to 59.6.0.

### DIFF
--- a/cookbooks/ros2_windows/recipes/pip_installs.rb
+++ b/cookbooks/ros2_windows/recipes/pip_installs.rb
@@ -47,7 +47,7 @@ development_pip_packages = %w[
 #
 execute 'pip_update' do
   command lazy {
-    "#{node.run_state[:python_dir]}\\python.exe -m pip install -U pip setuptools"
+    "#{node.run_state[:python_dir]}\\python.exe -m pip install -U pip setuptools==59.6.0"
   }
 end
 


### PR DESCRIPTION
This matches what is in Ubuntu Jammy, and also works around
an issue with newer setuptools and Windows Debug.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is a follow-up from https://github.com/ros2/ci/pull/650 , and makes it so that the cookbooks match what we are "overridding" in the CI scripts.