### PR TITLE
Pin pydot to 1.4.2.

### DIFF
--- a/cookbooks/ros2_windows/recipes/pip_installs.rb
+++ b/cookbooks/ros2_windows/recipes/pip_installs.rb
@@ -1,5 +1,5 @@
 required_pip_packages = %w[
-  pydot
+  pydot==1.4.2
   PyQt5==5.15.0
   vcstool
   colcon-common-extensions


### PR DESCRIPTION
This is the version that matches what is in Ubuntu 22.04

Along with a PR to https://github.com/ros2/ci, this should fix the failing tests on Windows: https://ci.ros2.org/view/nightly/job/nightly_win_rel/2912/#showFailuresLink