### PR TITLE
Remove installation of log4cxx.

### DIFF
--- a/cookbooks/ros2_windows/recipes/chocolatey_installs.rb
+++ b/cookbooks/ros2_windows/recipes/chocolatey_installs.rb
@@ -31,7 +31,6 @@ custom_chocolatey_packages = {
   'bullet' => 'bullet.3.17',
   'cunit' => 'cunit.2.1.3',
   'eigen' => 'eigen.3.3.4',
-  'log4cxx' => 'log4cxx.0.10.0',
   'tinyxml2' => 'tinyxml2.6.0.0'
 }
 


### PR DESCRIPTION
We no longer require it for any of the active distributions.

Still a draft while I test out CI for it over on https://github.com/ros2/ci