### PR TITLE
Make sure to pip install argcomplete for Python.

### DIFF
--- a/cookbooks/ros2_windows/recipes/pip_installs.rb
+++ b/cookbooks/ros2_windows/recipes/pip_installs.rb
@@ -1,6 +1,7 @@
 required_pip_packages = %w[
   pydot==1.4.2
   PyQt5==5.15.0
+  argcomplete==1.8.1
   vcstool
   colcon-common-extensions
   catkin_pkg


### PR DESCRIPTION
We need it for e.g. ros2cli and sros2.

A draft for now while I run CI on it.