### PR TITLE
Unpin zeven_zip cookbook to ~> 4.0.0

### DIFF
--- a/cookbooks/ros2_windows/metadata.rb
+++ b/cookbooks/ros2_windows/metadata.rb
@@ -19,5 +19,5 @@ chef_version '>= 12.1' if respond_to?(:chef_version)
 #
 # source_url 'https://github.com/osrf/chef-osrf'
 depends 'chocolatey', '3.0.0'
-depends 'seven_zip', '3.2.0'
+depends 'seven_zip', '~> 4.0.0'
 depends 'windows', '7.0.2'

--- a/cookbooks/ros2_windows/metadata.rb
+++ b/cookbooks/ros2_windows/metadata.rb
@@ -19,5 +19,4 @@ chef_version '>= 12.1' if respond_to?(:chef_version)
 #
 # source_url 'https://github.com/osrf/chef-osrf'
 depends 'chocolatey', '3.0.0'
-depends 'seven_zip', '~> 4'
 depends 'windows', '7.0.2'

--- a/cookbooks/ros2_windows/metadata.rb
+++ b/cookbooks/ros2_windows/metadata.rb
@@ -19,5 +19,5 @@ chef_version '>= 12.1' if respond_to?(:chef_version)
 #
 # source_url 'https://github.com/osrf/chef-osrf'
 depends 'chocolatey', '3.0.0'
-depends 'seven_zip', '~> 4.0.0'
+depends 'seven_zip', '~> 4'
 depends 'windows', '7.0.2'

--- a/cookbooks/ros2_windows/recipes/opencv.rb
+++ b/cookbooks/ros2_windows/recipes/opencv.rb
@@ -1,7 +1,12 @@
-seven_zip_archive 'open_cv_zip' do
-  path 'C:\\'
+remote_file 'C:\\opencv-3.4.6-vc16.VS2019.zip' do
   source 'https://github.com/ros2/ros2/releases/download/opencv-archives/opencv-3.4.6-vc16.VS2019.zip'
+end
+
+archive_file 'open_cv_zip' do
+  destination 'C:\\'
+  path 'C:\opencv-3.4.6-vc16.VS2019.zip'
   overwrite true
+  action :extract
 end
 
 windows_env 'OpenCV_DIR' do

--- a/cookbooks/ros2_windows/recipes/opencv.rb
+++ b/cookbooks/ros2_windows/recipes/opencv.rb
@@ -4,7 +4,7 @@ end
 
 archive_file 'open_cv_zip' do
   destination 'C:\\'
-  path 'C:\opencv-3.4.6-vc16.VS2019.zip'
+  path 'C:\\opencv-3.4.6-vc16.VS2019.zip'
   overwrite true
   action :extract
 end

--- a/cookbooks/ros2_windows/recipes/opensplice.rb
+++ b/cookbooks/ros2_windows/recipes/opensplice.rb
@@ -3,7 +3,7 @@ remote_file 'C:\\PXXX-VortexOpenSplice-6.9.190925OSS-HDE-x86_64.win-vs2019-insta
 end
 
 archive_file 'opensplice' do
-  destination 'C:\opensplice'
+  destination 'C:\\opensplice'
   source 'C:\\PXXX-VortexOpenSplice-6.9.190925OSS-HDE-x86_64.win-vs2019-installer.zip'
   overwrite true
   action :extract

--- a/cookbooks/ros2_windows/recipes/opensplice.rb
+++ b/cookbooks/ros2_windows/recipes/opensplice.rb
@@ -1,7 +1,12 @@
-seven_zip_archive 'opensplice' do
-  path 'C:\opensplice'
+remote_file 'C:\\PXXX-VortexOpenSplice-6.9.190925OSS-HDE-x86_64.win-vs2019-installer.zip' do
   source 'https://github.com/ADLINK-IST/opensplice/releases/download/OSPL_V6_9_190925OSS_RELEASE/PXXX-VortexOpenSplice-6.9.190925OSS-HDE-x86_64.win-vs2019-installer.zip'
+end
+
+archive_file 'opensplice' do
+  destination 'C:\opensplice'
+  source 'C:\\PXXX-VortexOpenSplice-6.9.190925OSS-HDE-x86_64.win-vs2019-installer.zip'
   overwrite true
+  action :extract
 end
 
 windows_env 'OSPL_HOME' do

--- a/cookbooks/ros2_windows/recipes/ros2.rb
+++ b/cookbooks/ros2_windows/recipes/ros2.rb
@@ -1,7 +1,5 @@
 include_recipe 'chocolatey'
 
-# Using seven_zip also for general zip files because it can download and extract in a single resource
-include_recipe 'seven_zip'
 include_recipe 'ros2_windows::visual_studio'
 include_recipe 'ros2_windows::python'
 include_recipe 'ros2_windows::pip_installs'

--- a/cookbooks/ros2_windows/recipes/ros2_binaries.rb
+++ b/cookbooks/ros2_windows/recipes/ros2_binaries.rb
@@ -1,7 +1,12 @@
 release_version = node['ros2_windows']['ros_distro']
 build_type = node['ros2_windows']['build_type']
 
-seven_zip_archive 'ros2' do
+remote_file 'C:\\ros2_windows.zip' do
   source node['ros2_windows'][release_version][build_type]
-  path node['ros2_windows']['ros2_ws']
+end
+
+archive_file 'ros2' do
+  path 'C:\\ros2_windows.zip'
+  destination node['ros2_windows']['ros2_ws']
+  action :extract
 end

--- a/cookbooks/ros2_windows/recipes/rti_connext.rb
+++ b/cookbooks/ros2_windows/recipes/rti_connext.rb
@@ -16,8 +16,6 @@ end
 
 connext_params = node['ros2_windows']['rti_connext']
 
-include_recipe 'seven_zip'
-
 output="#{Chef::JSONCompat.to_json_pretty(node.to_hash)}"
 
 # These will fail if the rti_connext parameters have not been specified because the defaults are 'nil'
@@ -116,10 +114,15 @@ powershell_script 'copy_license_file' do
   code "copy #{connext_params['license_file']} C:/connext/"
 end
 
-seven_zip_archive 'openssl_zip' do
-  path 'C:/connext/'
+remote_file 'C:\\openssl.zip' do
   source openssl_installer_zip
+end
+
+archive_file 'openssl_zip' do
+  destination 'C:/connext/'
+  path 'C:\\openssl.zip'
   overwrite false
+  action :extract
 end
 
 windows_env 'RTI_LICENSE_FILE' do

--- a/cookbooks/ros2_windows/recipes/xmllint.rb
+++ b/cookbooks/ros2_windows/recipes/xmllint.rb
@@ -1,18 +1,28 @@
-seven_zip_archive 'libxml2' do
-  path 'C:\\xmllint'
+remote_file 'C:\\libxml2-2.9.3-win32-x86_64.7z' do
   source 'https://www.zlatkovic.com/pub/libxml/64bit/libxml2-2.9.3-win32-x86_64.7z'
-  overwrite true
 end
-
-seven_zip_archive 'zlib' do
-  path 'C:\\xmllint'
+remote_file 'C:\\zlib-1.2.8-win32-x86_64.7z' do
   source 'https://www.zlatkovic.com/pub/libxml/64bit/zlib-1.2.8-win32-x86_64.7z'
+end
+remote_file 'C:\\iconv-1.14-win32-x86_64.7z' do
+  source 'https://www.zlatkovic.com/pub/libxml/64bit/iconv-1.14-win32-x86_64.7z'
+end
+
+archive_file 'libxml2' do
+  destination 'C:\\xmllint'
+  path 'C:\\libxml2-2.9.3-win32-x86_64.7z'
   overwrite true
 end
 
-seven_zip_archive 'iconv' do
-  path 'C:\\xmllint'
-  source 'https://www.zlatkovic.com/pub/libxml/64bit/iconv-1.14-win32-x86_64.7z'
+archive_file 'zlib' do
+  destination 'C:\\xmllint'
+  path 'C:\\zlib-1.2.8-win32-x86_64.7z'
+  overwrite true
+end
+
+archive_file 'iconv' do
+  destination 'C:\\xmllint'
+  path 'C:\\iconv-1.14-win32-x86_64.7z'
   overwrite true
 end
 


### PR DESCRIPTION
### Description
This is the corresponding pair of 
- https://github.com/ros2/ci/pull/742 

that unpins the `seven_zip` cookbook to the latest major version `4`. 
This is necessary since the goal is to move CI to latest chef version `18`.