### PR TITLE
Bump Python to 3.12.3 for rolling

### DIFF
--- a/cookbooks/ros2_windows/recipes/python.rb
+++ b/cookbooks/ros2_windows/recipes/python.rb
@@ -2,7 +2,7 @@ python_versions = {
   "humble" => "3.8.3",
   "iron" => "3.8.3",
   "jazzy" => "3.8.3",
-  "rolling" => "3.8.3",
+  "rolling" => "3.12.3",
 }.freeze
 
 python_version = python_versions[node["ros2_windows"]["ros_distro"]]


### PR DESCRIPTION
chocolatey [ships python3 3.12.3](https://community.chocolatey.org/packages/python3/3.12.3) and minimum requirement for Jazzy is [Python 3.9](https://www.ros.org/reps/rep-2000.html#jazzy-jalisco-may-2024-may-2029)

This PR suggests bumping python to 3.12.3 for rolling and then see to apply it to Jazzy.

TBH I don't know how this part of the infrastructure works and if there are discussion and work in that direction already ongoing :sweat_smile: 

The initial motivation is because CI fails on Windows when Python 3.9 features are used: https://github.com/ros2/sros2/pull/300#issuecomment-2097922214


---

Once the approach validated: I can open the related PRs to REP-2000 and ros2/ci