### PR TITLE
Add support for more than one release of Visual Studio

### DIFF
--- a/cookbooks/ros2_windows/attributes/visual_studio.rb
+++ b/cookbooks/ros2_windows/attributes/visual_studio.rb
@@ -1,2 +1,3 @@
 # Visual studio version, "buildtools" or "community"
 default['ros2_windows']['vs_version'] = 'buildtools'
+default['ros2_windows']['vs_release'] = '2019'

--- a/cookbooks/ros2_windows/recipes/visual_studio.rb
+++ b/cookbooks/ros2_windows/recipes/visual_studio.rb
@@ -32,11 +32,13 @@ installer_options = base_options + package_arguments
 
 case node['ros2_windows']['vs_release']
 when '2022'
-  visual_studio_source = "https://aka.ms/vs/17/release/vs_#{node['ros2_windows']['vs_version']}.exe"
-  visual_studio_path = "c:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\#{vs_version_camel_case}"
-else 
+  visual_studio_source = 'https://aka.ms/vs/17/release/vs_%s.exe' % node['ros2_windows']['vs_version']
+  visual_studio_path = 'c:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\%s' % vs_version_camel_case
+when '2019' 
   visual_studio_source = 'https://aka.ms/vs/16/release/vs_%s.exe' % node['ros2_windows']['vs_version']
   visual_studio_path = 'c:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\%s' % vs_version_camel_case
+else 
+  raise 'Unsupported Visual Studio version' % node['ros2_windows']['vs_release']
 end
 
 vs_version_camel_case = {

--- a/cookbooks/ros2_windows/recipes/visual_studio.rb
+++ b/cookbooks/ros2_windows/recipes/visual_studio.rb
@@ -32,8 +32,8 @@ installer_options = base_options + package_arguments
 
 case node['ros2_windows']['vs_release']
 when '2022'
-  visual_studio_source = 'https://aka.ms/vs/17/release/vs_%s.exe' % node['ros2_windows']['vs_version']
-  visual_studio_path = 'c:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\%s' % vs_version_camel_case
+  visual_studio_source = "https://aka.ms/vs/17/release/vs_#{node['ros2_windows']['vs_version']}.exe"
+  visual_studio_path = "c:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\#{vs_version_camel_case}"
 else 
   visual_studio_source = 'https://aka.ms/vs/16/release/vs_%s.exe' % node['ros2_windows']['vs_version']
   visual_studio_path = 'c:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\%s' % vs_version_camel_case

--- a/cookbooks/ros2_windows/recipes/visual_studio.rb
+++ b/cookbooks/ros2_windows/recipes/visual_studio.rb
@@ -38,7 +38,7 @@ when '2019'
   visual_studio_source = 'https://aka.ms/vs/16/release/vs_%s.exe' % node['ros2_windows']['vs_version']
   visual_studio_path = 'c:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\%s' % vs_version_camel_case
 else 
-  raise 'Unsupported Visual Studio version' % node['ros2_windows']['vs_release']
+  raise "Unsupported Visual Studio version: #{node['ros2_windows']['vs_release']}"
 end
 
 vs_version_camel_case = {

--- a/cookbooks/ros2_windows/recipes/visual_studio.rb
+++ b/cookbooks/ros2_windows/recipes/visual_studio.rb
@@ -30,7 +30,14 @@ base_options = '--quiet --wait --norestart '
 
 installer_options = base_options + package_arguments
 
-visual_studio_source = 'https://aka.ms/vs/16/release/vs_%s.exe' % node['ros2_windows']['vs_version']
+case node['ros2_windows']['vs_release']
+when '2022'
+  visual_studio_source = 'https://aka.ms/vs/17/release/vs_%s.exe' % node['ros2_windows']['vs_version']
+  visual_studio_path = 'c:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\%s' % vs_version_camel_case
+else 
+  visual_studio_source = 'https://aka.ms/vs/16/release/vs_%s.exe' % node['ros2_windows']['vs_version']
+  visual_studio_path = 'c:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\%s' % vs_version_camel_case
+end
 
 vs_version_camel_case = {
   'buildtools' => 'BuildTools',
@@ -39,7 +46,6 @@ vs_version_camel_case = {
   'enterprise' => 'Enterprise'
 }[node['ros2_windows']['vs_version']]
 
-visual_studio_path = 'c:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\%s' % vs_version_camel_case
 windows_package 'Update VS' do
   source visual_studio_source
   installer_type :custom

--- a/cookbooks/ros2_windows/recipes/visual_studio.rb
+++ b/cookbooks/ros2_windows/recipes/visual_studio.rb
@@ -41,9 +41,11 @@ case node['ros2_windows']['vs_release']
 when '2022'
   visual_studio_source = 'https://aka.ms/vs/17/release/vs_%s.exe' % node['ros2_windows']['vs_version']
   visual_studio_path = 'c:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\%s' % vs_version_camel_case
+  vc_target_path = 'MSBuild\\Microsoft\\VC\\v170\\'
 when '2019' 
   visual_studio_source = 'https://aka.ms/vs/16/release/vs_%s.exe' % node['ros2_windows']['vs_version']
   visual_studio_path = 'c:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\%s' % vs_version_camel_case
+  vc_target_path = 'MSBuild\\Microsoft\\VC\\v160\\'
 else 
   raise "Unsupported Visual Studio version: #{node['ros2_windows']['vs_release']}"
 end
@@ -70,6 +72,6 @@ end
 
 windows_env 'VCTargetsPath' do
   key_name 'VCTargetsPath'
-  value File.join(visual_studio_path, 'MSBuild\\Microsoft\\VC\\v160\\')
+  value File.join(visual_studio_path, vc_target_path)
   action :create
 end

--- a/cookbooks/ros2_windows/recipes/visual_studio.rb
+++ b/cookbooks/ros2_windows/recipes/visual_studio.rb
@@ -30,6 +30,13 @@ base_options = '--quiet --wait --norestart '
 
 installer_options = base_options + package_arguments
 
+vs_version_camel_case = {
+  'buildtools' => 'BuildTools',
+  'community' => 'Community',
+  'professional' => 'Professional',
+  'enterprise' => 'Enterprise'
+}[node['ros2_windows']['vs_version']]
+
 case node['ros2_windows']['vs_release']
 when '2022'
   visual_studio_source = 'https://aka.ms/vs/17/release/vs_%s.exe' % node['ros2_windows']['vs_version']
@@ -41,12 +48,6 @@ else
   raise "Unsupported Visual Studio version: #{node['ros2_windows']['vs_release']}"
 end
 
-vs_version_camel_case = {
-  'buildtools' => 'BuildTools',
-  'community' => 'Community',
-  'professional' => 'Professional',
-  'enterprise' => 'Enterprise'
-}[node['ros2_windows']['vs_version']]
 
 windows_package 'Update VS' do
   source visual_studio_source

--- a/cookbooks/ros2_windows/recipes/visual_studio.rb
+++ b/cookbooks/ros2_windows/recipes/visual_studio.rb
@@ -42,11 +42,11 @@ when '2022'
   visual_studio_source = 'https://aka.ms/vs/17/release/vs_%s.exe' % node['ros2_windows']['vs_version']
   visual_studio_path = 'c:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\%s' % vs_version_camel_case
   vc_target_path = 'MSBuild\\Microsoft\\VC\\v170\\'
-when '2019' 
+when '2019'
   visual_studio_source = 'https://aka.ms/vs/16/release/vs_%s.exe' % node['ros2_windows']['vs_version']
   visual_studio_path = 'c:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\%s' % vs_version_camel_case
   vc_target_path = 'MSBuild\\Microsoft\\VC\\v160\\'
-else 
+else
   raise "Unsupported Visual Studio version: #{node['ros2_windows']['vs_release']}"
 end
 

--- a/roles/ros2-development.json
+++ b/roles/ros2-development.json
@@ -7,11 +7,12 @@
       "development": "true",
       "download_sources": "true",
       "vs_version": "buildtools",
+      "vs_release": "2019",
       "source": {
         "ros2.repos": "rolling"
       },
       "ros2_ws": "C:/dev/ros2_ws",
-      "install_connext": "false",
+      "install_connext": "false"
     }
   },
   "chef_type": "role",


### PR DESCRIPTION
### Description
Borrowing from the work done on #72, this PR adds the flexibility to specify VS release version on the `solo` file. 
Paired with: 
- https://github.com/ros2/ci/pull/786