### PR TITLE
Pin the PyQt5.sip dependency.

### DIFF
--- a/cookbooks/ros2_windows/recipes/pip_installs.rb
+++ b/cookbooks/ros2_windows/recipes/pip_installs.rb
@@ -27,7 +27,6 @@ ros2cli_network_dependency = {
   "jazzy" => "psutil",
   "rolling" => "psutil",
 }.freeze
-
 required_pip_packages << ros2cli_network_dependency[node["ros2_windows"]["ros_distro"]]
 
 pyparsing_dependency = {
@@ -36,8 +35,15 @@ pyparsing_dependency = {
   "jazzy" => "pyparsing==3.1.1",
   "rolling" => "pyparsing==3.1.1",
 }
-
 required_pip_packages << pyparsing_dependency[node["ros2_windows"]["ros_distro"]]
+
+pyqt5_sip_dependency = {
+  "humble" => "PyQt5-sip==12.9.1",
+  "iron" => "PyQt5-sip==12.9.1",
+  "jazzy" => "PyQt5-sip==12.13.0",
+  "rolling" => "PyQt5-sip==12.13.0",
+}
+required_pip_packages << pyqt5_sip_dependency[node["ros2_windows"]["ros_distro"]]
 
 development_pip_packages = %w[
   flake8


### PR DESCRIPTION
The latest version released on December 6, 2024 (12.16.0) no longer supports Python 3.8.  Unfortunately that is what we are still using for Windows, so pin this to the versions that are used in the respective Ubuntu versions (this will eventually be solved by switching to Conda, but we aren't there yet).