### PR TITLE
Pin EmPy to version 3.3.4.

### DIFF
--- a/cookbooks/ros2_windows/recipes/pip_installs.rb
+++ b/cookbooks/ros2_windows/recipes/pip_installs.rb
@@ -88,7 +88,7 @@ end
 
 execute 'pip_required' do
   command lazy {
-    "#{node.run_state[:python_dir]}\\python.exe -m pip install -U #{required_pip_packages.join(' ')}"
+    "#{node.run_state[:python_dir]}\\python.exe -m pip install -U \"#{required_pip_packages.join('" "')}\""
   }
 end
 

--- a/cookbooks/ros2_windows/recipes/pip_installs.rb
+++ b/cookbooks/ros2_windows/recipes/pip_installs.rb
@@ -24,7 +24,7 @@ required_pip_packages = %w[
   colcon-test-result
   colcon-zsh
   cryptography
-  EmPy
+  EmPy==3.3.4
   fastjsonschema==2.19.0
   jsonschema
   lark-parser

--- a/cookbooks/ros2_windows/recipes/pip_installs.rb
+++ b/cookbooks/ros2_windows/recipes/pip_installs.rb
@@ -24,7 +24,7 @@ required_pip_packages = %w[
   colcon-test-result
   colcon-zsh
   cryptography
-  EmPy==3.3.4
+  EmPy<4
   fastjsonschema==2.19.0
   jsonschema
   lark-parser


### PR DESCRIPTION
This should fix failing builds on e.g. Humble, like https://github.com/ros2/rosbag2/pull/1829#issuecomment-2529699763